### PR TITLE
Better path alias for Subsite child pages

### DIFF
--- a/localgov_subsites_extras.module
+++ b/localgov_subsites_extras.module
@@ -96,8 +96,9 @@ function localgov_subsites_extras_pathauto_alias_alter(&$alias, array &$context)
     return;
   }
 
-  $subsite_home_path_alias = $subsite_home->path?->alias;
-  if (is_null($subsite_home_path_alias)) {
+  $subsite_home_path_alias        = $subsite_home->toUrl()->toString();
+  $has_no_subsite_home_path_alias = $subsite_home_path_alias === "/node/{$subsite_home->id()}";
+  if ($has_no_subsite_home_path_alias) {
     return;
   }
 

--- a/localgov_subsites_extras.module
+++ b/localgov_subsites_extras.module
@@ -7,6 +7,8 @@
 
 declare(strict_types=1);
 
+use Drupal\node\NodeInterface;
+
 /**
  * Implements hook_preprocess_node().
  *
@@ -70,4 +72,34 @@ function localgov_subsites_extras_entity_bundle_create($entity_type_id, $bundle)
     $type->save();
   }
 
+}
+
+/**
+ * Implements hook_pathauto_alias_alter().
+ *
+ * Prepends Subsite homepage path alias to child page path aliases.
+ *
+ * @todo Fix bulk update scenario.
+ * @todo Automated tests.
+ */
+function localgov_subsites_extras_pathauto_alias_alter(&$alias, array &$context) {
+
+  if ($context['module'] !== 'node') {
+    return;
+  }
+
+  $src_node = $context['data']['node'];
+
+  $subsite_home = Drupal::service('localgov_subsites_extras.service')->getHomePage($src_node);
+  if (!$subsite_home instanceof NodeInterface) {
+    return;
+  }
+  $subsite_home_path = $subsite_home->toUrl()->toString();
+
+  $has_subsite_alias_prefix = str_starts_with($alias, $subsite_home_path);
+  if ($has_subsite_alias_prefix) {
+    return;
+  }
+
+  $alias = $subsite_home_path . $alias;
 }

--- a/localgov_subsites_extras.module
+++ b/localgov_subsites_extras.module
@@ -78,8 +78,6 @@ function localgov_subsites_extras_entity_bundle_create($entity_type_id, $bundle)
  * Implements hook_pathauto_alias_alter().
  *
  * Prepends Subsite homepage path alias to child page path aliases.
- *
- * @todo Automated tests.
  */
 function localgov_subsites_extras_pathauto_alias_alter(&$alias, array &$context) {
 

--- a/localgov_subsites_extras.module
+++ b/localgov_subsites_extras.module
@@ -86,7 +86,6 @@ function localgov_subsites_extras_pathauto_alias_alter(&$alias, array &$context)
   }
 
   $src_node = $context['data']['node'];
-
   $subsite_home = Drupal::service('localgov_subsites_extras.service')->getHomePage($src_node);
   if (!$subsite_home instanceof NodeInterface) {
     return;
@@ -97,11 +96,15 @@ function localgov_subsites_extras_pathauto_alias_alter(&$alias, array &$context)
     return;
   }
 
-  $subsite_home_path = $subsite_home->toUrl()->toString();
-  $has_subsite_alias_prefix = str_starts_with($alias, $subsite_home_path);
+  $subsite_home_path_alias = $subsite_home->path?->alias;
+  if (is_null($subsite_home_path_alias)) {
+    return;
+  }
+
+  $has_subsite_alias_prefix = str_starts_with($alias, $subsite_home_path_alias);
   if ($has_subsite_alias_prefix) {
     return;
   }
 
-  $alias = $subsite_home_path . $alias;
+  $alias = $subsite_home_path_alias . $alias;
 }

--- a/localgov_subsites_extras.module
+++ b/localgov_subsites_extras.module
@@ -79,7 +79,6 @@ function localgov_subsites_extras_entity_bundle_create($entity_type_id, $bundle)
  *
  * Prepends Subsite homepage path alias to child page path aliases.
  *
- * @todo Fix bulk update scenario.
  * @todo Automated tests.
  */
 function localgov_subsites_extras_pathauto_alias_alter(&$alias, array &$context) {
@@ -94,8 +93,13 @@ function localgov_subsites_extras_pathauto_alias_alter(&$alias, array &$context)
   if (!$subsite_home instanceof NodeInterface) {
     return;
   }
-  $subsite_home_path = $subsite_home->toUrl()->toString();
 
+  $is_child_page = $subsite_home->id() !== $src_node->id();
+  if (!$is_child_page) {
+    return;
+  }
+
+  $subsite_home_path = $subsite_home->toUrl()->toString();
   $has_subsite_alias_prefix = str_starts_with($alias, $subsite_home_path);
   if ($has_subsite_alias_prefix) {
     return;

--- a/src/Service/SubsiteService.php
+++ b/src/Service/SubsiteService.php
@@ -74,7 +74,7 @@ class SubsiteService implements SubsiteServiceInterface {
    * Is the given node a subsite root node?
    */
   private function isSubsiteType(NodeInterface $node): bool {
-    return in_array($node->bundle(), $this->subsiteTypes);
+    return in_array($node->bundle(), $this->subsiteTypes, strict: TRUE);
   }
 
   /**

--- a/src/Service/SubsiteService.php
+++ b/src/Service/SubsiteService.php
@@ -43,10 +43,10 @@ class SubsiteService implements SubsiteServiceInterface {
   /**
    * {@inheritDoc}
    */
-  public function getHomePage(): ?NodeInterface {
+  public function getHomePage(?NodeInterface $node = NULL): ?NodeInterface {
 
     if ($this->searched === FALSE) {
-      $this->subsiteHomePage = $this->findHomePage();
+      $this->subsiteHomePage = $this->findHomePage($node);
       $this->searched = TRUE;
     }
 

--- a/src/Service/SubsiteServiceInterface.php
+++ b/src/Service/SubsiteServiceInterface.php
@@ -15,7 +15,7 @@ interface SubsiteServiceInterface {
    * This will only call ::findHomePage() once per request, so it's fine to call
    * from multiple preprocess functions without a performance penalty.
    */
-  public function getHomePage(): ?NodeInterface;
+  public function getHomePage(?NodeInterface $node = NULL): ?NodeInterface;
 
   /**
    * Gets the theme of the current subsite, if there is one.

--- a/src/Service/SubsiteServiceInterface.php
+++ b/src/Service/SubsiteServiceInterface.php
@@ -14,6 +14,10 @@ interface SubsiteServiceInterface {
    *
    * This will only call ::findHomePage() once per request, so it's fine to call
    * from multiple preprocess functions without a performance penalty.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   (optional) Useful for determining the Subsite homepage for a given child
+   *   page.
    */
   public function getHomePage(?NodeInterface $node = NULL): ?NodeInterface;
 

--- a/tests/src/Functional/PathAliasTest.php
+++ b/tests/src/Functional/PathAliasTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Drupal\Tests\localgov_subsites_extras\Functional;
+
+use Drupal\menu_link_content\Entity\MenuLinkContent;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Path alias pattern tests for subsites extras.
+ */
+class PathAliasTest extends BrowserTestBase {
+
+  /**
+   * Ensures path alias pattern.
+   *
+   * Checks that the Subsite homepage path alias is prepended to child page path
+   * aliases.
+   */
+  public function testPathAlias() {
+
+    $subsiteHome = $this->getNodeByTitle(self::SUBSITE_HOMEPAGE_TITLE);
+    $subsiteChild = $this->getNodeByTitle(self::SUBSITE_CHILDPAGE_TITLE);
+    $subsiteHomePathAlias  = $subsiteHome->path?->alias ?? '/something';
+    $subsiteChildPathAlias = $subsiteChild->path?->alias ?? '/completely/different';
+
+    $hasExpectedPathAliasPattern = str_starts_with($subsiteChildPathAlias, $subsiteHomePathAlias);
+    $this->assertTrue($hasExpectedPathAliasPattern, 'Subsite child path alias is prefixed with parent path alias.');
+  }
+
+  /**
+   * Sets up a small subsite.
+   */
+  protected function setUp(): void {
+
+    parent::setUp();
+
+    $subsiteHome = $this->createNode([
+      'type'   => 'localgov_subsites_overview',
+      'title'  => self::SUBSITE_HOMEPAGE_TITLE,
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+
+    $subsiteHomeMenuLink = MenuLinkContent::create([
+      'link'      => [['uri' => 'entity:node/' . $subsiteHome->id()]],
+      'title'     => $subsiteHome->label(),
+      'menu_name' => 'subsites',
+    ]);
+    $subsiteHomeMenuLink->save();
+
+    $subsiteChild = $this->createNode([
+      'type'   => 'localgov_services_page',
+      'title'  => self::SUBSITE_CHILDPAGE_TITLE,
+      'status' => NodeInterface::PUBLISHED,
+      'body' => [
+        'summary' => $this->randomString(16),
+        'value'   => $this->randomString(64),
+      ],
+    ]);
+
+    MenuLinkContent::create([
+      'link'   => [['uri' => 'entity:node/' . $subsiteChild->id()]],
+      'title'  => $subsiteChild->label(),
+      'menu_name' => 'subsites',
+      'parent'    => 'menu_link_content:' . $subsiteHomeMenuLink->uuid(),
+    ])->save();
+  }
+
+  const SUBSITE_HOMEPAGE_TITLE  = 'A subsite homepage';
+  const SUBSITE_CHILDPAGE_TITLE = 'A subsite childpage';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'localgov_subsites',
+    'localgov_subsites_extras',
+    'localgov_services_page',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+}

--- a/tests/src/Functional/SubsiteTest.php
+++ b/tests/src/Functional/SubsiteTest.php
@@ -27,7 +27,7 @@ class SubsiteTest extends BrowserTestBase {
   /**
    * Test that we can set up a subsite using this module.
    */
-  public function testChildPageAttributeAndPathAlias() {
+  public function testChildPageAttributes() {
 
     $user = $this->createUser([], 'admintestuser', TRUE);
 
@@ -63,11 +63,6 @@ class SubsiteTest extends BrowserTestBase {
       'menu_name' => 'subsites',
       'parent' => 'menu_link_content:' . $parentMenuLink->uuid(),
     ])->save();
-
-    $parentNodePathAlias = $parentNode->path?->alias ?? '/something';
-    $childNodePathAlias = $childNode->path?->alias ?? '/completely/different';
-    $fulfillsExpectedPathAliasPattern = str_starts_with($childNodePathAlias, $parentNodePathAlias);
-    $this->assertSession()->assert($fulfillsExpectedPathAliasPattern, 'Child path alias is prefixed with parent path alias.');
 
     $this->drupalGet('/node/' . $childNode->id());
 

--- a/tests/src/Functional/SubsiteTest.php
+++ b/tests/src/Functional/SubsiteTest.php
@@ -27,7 +27,7 @@ class SubsiteTest extends BrowserTestBase {
   /**
    * Test that we can set up a subsite using this module.
    */
-  public function testLoadAdminView() {
+  public function testChildPageAttributeAndPathAlias() {
 
     $user = $this->createUser([], 'admintestuser', TRUE);
 
@@ -63,6 +63,11 @@ class SubsiteTest extends BrowserTestBase {
       'menu_name' => 'subsites',
       'parent' => 'menu_link_content:' . $parentMenuLink->uuid(),
     ])->save();
+
+    $parentNodePathAlias = $parentNode->path?->alias ?? '/something';
+    $childNodePathAlias = $childNode->path?->alias ?? '/completely/different';
+    $fulfillsExpectedPathAliasPattern = str_starts_with($childNodePathAlias, $parentNodePathAlias);
+    $this->assert($fulfillsExpectedPathAliasPattern);
 
     $this->drupalGet('/node/' . $childNode->id());
 

--- a/tests/src/Functional/SubsiteTest.php
+++ b/tests/src/Functional/SubsiteTest.php
@@ -67,7 +67,7 @@ class SubsiteTest extends BrowserTestBase {
     $parentNodePathAlias = $parentNode->path?->alias ?? '/something';
     $childNodePathAlias = $childNode->path?->alias ?? '/completely/different';
     $fulfillsExpectedPathAliasPattern = str_starts_with($childNodePathAlias, $parentNodePathAlias);
-    $this->assert($fulfillsExpectedPathAliasPattern);
+    $this->assertSession()->assert($fulfillsExpectedPathAliasPattern, 'Child path alias is prefixed with parent path alias.');
 
     $this->drupalGet('/node/' . $childNode->id());
 


### PR DESCRIPTION
## What does this change?
Currently, path aliases of child pages of Subsites are missing the Subsite homepage's path alias.  This breaks breadcrumbs.   This is particularly evident when Service pages are used child pages.  For example, if a Service page called "Child" is added to a Subsite homepage called "Parent", the child page still gets a path alias of `/child`.  This change ensures that child pages get path aliases of the `/parent/child` format.

## How to test
- Add a child page to a Subsite.  The child page can be of any content type.
- Note the path alias of the Subsite homepage.
- The above path alias should be present as a prefix of the child page's path alias.