### PR TITLE
Better SubsiteService::walkMenuTree implementation.

### DIFF
--- a/src/Service/SubsiteService.php
+++ b/src/Service/SubsiteService.php
@@ -98,7 +98,7 @@ class SubsiteService implements SubsiteServiceInterface {
     // Otherwise, get the parent link of the current link and try again.
     $parentMenuLinkID = $menuLink->getParent();
     if ($parentMenuLinkID !== '') {
-      $parentMenuLink = $this->menuLinkManager->getInstance(['id' => $parentMenuLinkID]);
+      $parentMenuLink = $this->menuLinkManager->createInstance($parentMenuLinkID);
       if ($parentMenuLink instanceof MenuLinkInterface) {
         return $this->walkMenuTree($parentMenuLink);
       }
@@ -110,8 +110,7 @@ class SubsiteService implements SubsiteServiceInterface {
   /**
    * Loads the node for the supplied menu link ID.
    */
-  private function loadNodeForMenuLink($menuLinkContentID): ?NodeInterface {
-    $menuLink = $this->menuLinkManager->createInstance($menuLinkContentID);
+  private function loadNodeForMenuLink($menuLink): ?NodeInterface {
     $pluginDefinition = $menuLink->getPluginDefinition();
 
     if (isset($pluginDefinition['route_parameters']['node'])) {

--- a/src/Service/SubsiteService.php
+++ b/src/Service/SubsiteService.php
@@ -51,7 +51,8 @@ class SubsiteService implements SubsiteServiceInterface {
    */
   public function getHomePage(?NodeInterface $node = NULL): ?NodeInterface {
 
-    if ($this->searched === FALSE) {
+    // If a node is passed, don't use the cached result.
+    if ($this->searched === FALSE || $node !== NULL) {
       $this->subsiteHomePage = $this->findHomePage($node);
       $this->searched = TRUE;
     }

--- a/src/Service/SubsiteService.php
+++ b/src/Service/SubsiteService.php
@@ -168,7 +168,7 @@ class SubsiteService implements SubsiteServiceInterface {
 
     $menuLink = $this->loadMenuLinkForNode($node);
     if ($menuLink instanceof MenuLinkInterface) {
-      $this->walkMenuTree($menuLink);
+      return $this->walkMenuTree($menuLink);
     }
 
     return NULL;

--- a/src/Service/SubsiteService.php
+++ b/src/Service/SubsiteService.php
@@ -7,6 +7,7 @@ namespace Drupal\localgov_subsites_extras\Service;
 use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Menu\MenuLinkInterface;
 use Drupal\Core\Menu\MenuLinkManagerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\node\NodeInterface;
@@ -85,22 +86,24 @@ class SubsiteService implements SubsiteServiceInterface {
   /**
    * Walks up the menu tree to look for a subsite homepage node.
    */
-  private function walkMenuTree(NodeInterface $node): ?NodeInterface {
+  private function walkMenuTree(MenuLinkInterface $menuLink): ?NodeInterface {
 
-    if ($this->isSubsiteType($node)) {
+    // Get the node associated with this menu link if there is one.
+    // If there is one and it's a subsite homepage, we're done.
+    $node = $this->loadNodeForMenuLink($menuLink);
+    if (($node instanceof NodeInterface) && $this->isSubsiteType($node)) {
       return $node;
     }
 
-    $result = $this->menuLinkManager->loadLinksByRoute('entity.node.canonical', ['node' => $node->id()]);
-
-    if ($result !== []) {
-      $menuLink = reset($result);
-      $parentMenuLinkID = $menuLink->getParent();
-      if ($parentMenuLinkID !== '') {
-        $parentNode = $this->loadNodeForMenuLink($parentMenuLinkID);
-        return ($parentNode instanceof NodeInterface) ? $this->walkMenuTree($parentNode) : NULL;
+    // Otherwise, get the parent link of the current link and try again.
+    $parentMenuLinkID = $menuLink->getParent();
+    if ($parentMenuLinkID !== '') {
+      $parentMenuLink = $this->menuLinkManager->getInstance(['id' => $parentMenuLinkID]);
+      if ($parentMenuLink instanceof MenuLinkInterface) {
+        return $this->walkMenuTree($parentMenuLink);
       }
     }
+
     return NULL;
   }
 
@@ -119,6 +122,19 @@ class SubsiteService implements SubsiteServiceInterface {
         ->load($node_id);
 
       return $node;
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Loads the menu link for the supplied node.
+   */
+  private function loadMenuLinkForNode(NodeInterface $node): ?MenuLinkInterface {
+    $result = $this->menuLinkManager->loadLinksByRoute('entity.node.canonical', ['node' => $node->id()]);
+
+    if ($result !== []) {
+      return reset($result);
     }
 
     return NULL;
@@ -150,7 +166,12 @@ class SubsiteService implements SubsiteServiceInterface {
       $this->subsiteTypes = $subsiteTypes;
     }
 
-    return $this->walkMenuTree($node);
+    $menuLink = $this->loadMenuLinkForNode($node);
+    if ($menuLink instanceof MenuLinkInterface) {
+      $this->walkMenuTree($menuLink);
+    }
+
+    return NULL;
   }
 
 }

--- a/tests/src/Functional/PathAliasTest.php
+++ b/tests/src/Functional/PathAliasTest.php
@@ -21,11 +21,7 @@ class PathAliasTest extends BrowserTestBase {
 
     $subsiteHome = $this->getNodeByTitle(self::SUBSITE_HOMEPAGE_TITLE);
     $subsiteChild = $this->getNodeByTitle(self::SUBSITE_CHILDPAGE_TITLE);
-    $subsiteHomePathAlias  = $subsiteHome->path?->alias ?? '/something';
-    $subsiteChildPathAlias = $subsiteChild->path?->alias ?? '/completely/different';
-
-    $hasExpectedPathAliasPattern = str_starts_with($subsiteChildPathAlias, $subsiteHomePathAlias);
-    $this->assertTrue($hasExpectedPathAliasPattern, 'Subsite child path alias is prefixed with parent path alias.');
+    self::assertStringStartsWith($subsiteHome->path->alias, $subsiteChild->path->alias);
   }
 
   /**
@@ -47,6 +43,7 @@ class PathAliasTest extends BrowserTestBase {
       'menu_name' => 'subsites',
     ]);
     $subsiteHomeMenuLink->save();
+    $subsiteHome->save();
 
     $subsiteChild = $this->createNode([
       'type'   => 'localgov_services_page',
@@ -64,6 +61,7 @@ class PathAliasTest extends BrowserTestBase {
       'menu_name' => 'subsites',
       'parent'    => 'menu_link_content:' . $subsiteHomeMenuLink->uuid(),
     ])->save();
+    $subsiteChild->save();
   }
 
   const SUBSITE_HOMEPAGE_TITLE  = 'A subsite homepage';


### PR DESCRIPTION
Changed SubsiteService::walkMenuTree to accept a MenuLink instead of Node and walk the menu tree better, so it can bypass links to things that aren't nodes.

Fix for #20.