### PR TITLE
feat: support Drupal 11

### DIFF
--- a/localgov_subsites_extras.info.yml
+++ b/localgov_subsites_extras.info.yml
@@ -2,7 +2,7 @@ name: "LocalGov Subsites Extras"
 description: "Allows creation of subsites that use the menu system to determine hierarchy."
 package: LocalGov Drupal
 type: module
-core_version_requirement: ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - drupal:menu_ui
   - drupal:node


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

The only declared dependencies are drupal core which support Drupal 11, so it should be safe to bump the version to declare support for Drupal 11